### PR TITLE
Improved windows support

### DIFF
--- a/src/degree9/boot_exec.clj
+++ b/src/degree9/boot_exec.clj
@@ -43,10 +43,10 @@
   (OS/isFamilyWindows))
 
 (def ^:private executable-extensions
-  (if os-windows?
-    (-> (System/getenv "PATHEXT")
-        (string/split #";"))
-    [""]))
+  (cond-> [""]
+          os-windows?
+          (into (-> (System/getenv "PATHEXT")
+                    (string/split #";")))))
 
 (defn- get-executable
   [path name]


### PR DESCRIPTION
As discussed in https://github.com/degree9/boot-npm/issues/21

With this commit, boot-exec
- can now run .cmd, .bat files etc
- now supports the :local and :global options on windows